### PR TITLE
Map seed file when generating inputs

### DIFF
--- a/benchmark/redisgraph/generate_graph500_inputs.py
+++ b/benchmark/redisgraph/generate_graph500_inputs.py
@@ -1,13 +1,12 @@
 import os
 import sys
-import string
 
 # Read the node input file and translate the input IDs into a contiguous range.
 # Then, read the relation input file and translate all source and destination node IDs
 # to their updated contiguous values.
 
 # User-provided input data directory
-if len(sys.argv) < 2 or os.path.exists(sys.argv[1]) == False:
+if len(sys.argv) < 2 or os.path.exists(sys.argv[1]) is False:
     print("Usage: generate_inputs.py [path_to_inputs]")
     exit(1)
 
@@ -16,6 +15,7 @@ inputdir = sys.argv[1]
 # Input filenames
 nodefile = 'graph500-22_unique_node'
 relfile = 'graph500-22'
+seedfile = 'graph500-22-seed'
 
 # Output data directory
 datadir = 'data'
@@ -26,30 +26,21 @@ try:
 except OSError:
     pass
 
-# Count the number of unique nodes in the data set
-num_nodes = sum(1 for line in open(os.path.join(inputdir, nodefile)))
-
 updated_id = 0
 
 updated_node_file = open(os.path.join(datadir, nodefile), 'w')
 updated_node_file.write('id\n') # Output a header row
 updated_relation_file = open(os.path.join(datadir, relfile), 'w')
-
-# Scan the node file to find the highest node ID
-max_node = -1
-with open(os.path.join(inputdir, nodefile)) as f:
-    for line in f:
-        max_node = max(max_node, int(line))
+updated_seed_file = open(os.path.join(datadir, seedfile), 'w')
 
 # Map every node ID to its line number
 # and generate an updated node file.
-placement = [0]*(max_node + 1)
+placement = {}
 with open(os.path.join(inputdir, nodefile)) as f:
     for line in f:
-        node = int(line)
-        placement[node] = updated_id
-        updated_id += 1
+        placement[int(line)] = updated_id
         updated_node_file.write('%d\n' % (updated_id))
+        updated_id += 1
 
 with open(os.path.join(inputdir, relfile)) as f:
     for line in f:
@@ -63,5 +54,10 @@ with open(os.path.join(inputdir, relfile)) as f:
         # Output the updated edge description
         updated_relation_file.write("%d,%d\n" % (a, b))
 
+with open(os.path.join(inputdir, seedfile)) as f:
+    updated_seed_file.write(' '.join(str(placement[int(i)]) for i in f.read().split()))
+
+
 updated_node_file.close()
 updated_relation_file.close()
+updated_seed_file.close()

--- a/benchmark/redisgraph/generate_twitter_inputs.py
+++ b/benchmark/redisgraph/generate_twitter_inputs.py
@@ -1,13 +1,12 @@
 import os
 import sys
-import string
 
 # Read the node input file and translate the input IDs into a contiguous range.
 # Then, read the relation input file and translate all source and destination node IDs
 # to their updated contiguous values.
 
 # User-provided input data directory
-if len(sys.argv) < 2 or os.path.exists(sys.argv[1]) == False:
+if len(sys.argv) < 2 or os.path.exists(sys.argv[1]) is False:
     print("Usage: generate_inputs.py [path_to_inputs]")
     exit(1)
 
@@ -15,8 +14,8 @@ inputdir = sys.argv[1]
 
 # Input filenames
 nodefile = 'twitter_rv.net_unique_node'
-nodefile_out = 'twitter_rv_net_unique_node'
-relfile = 'twitter_rv'
+relfile = 'twitter_rv.net'
+seedfile = 'twitter_rv.net-seed'
 
 # Output data directory
 datadir = 'data'
@@ -27,30 +26,21 @@ try:
 except OSError:
     pass
 
-# Count the number of unique nodes in the data set
-num_nodes = sum(1 for line in open(os.path.join(inputdir, nodefile)))
-
 updated_id = 0
 
-updated_node_file = open(os.path.join(datadir, nodefile_out), 'w')
+updated_node_file = open(os.path.join(datadir, nodefile.replace('.', '_')), 'w')
 updated_node_file.write('id\n') # Output a header row
-updated_relation_file = open(os.path.join(datadir, relfile), 'w')
-
-# Scan the node file to find the highest node ID
-max_node = -1
-with open(os.path.join(inputdir, nodefile)) as f:
-    for line in f:
-        max_node = max(max_node, int(line))
+updated_relation_file = open(os.path.join(datadir, relfile.replace('.', '_')), 'w')
+updated_seed_file = open(os.path.join(datadir, seedfile.replace('.', '_')), 'w')
 
 # Map every node ID to its line number
 # and generate an updated node file.
-placement = [0]*(max_node + 1)
+placement = {}
 with open(os.path.join(inputdir, nodefile)) as f:
     for line in f:
-        node = int(line)
-        placement[node] = updated_id
-        updated_id += 1
+        placement[int(line)] = updated_id
         updated_node_file.write('%d\n' % (updated_id))
+        updated_id += 1
 
 with open(os.path.join(inputdir, relfile)) as f:
     for line in f:
@@ -64,5 +54,10 @@ with open(os.path.join(inputdir, relfile)) as f:
         # Output the updated edge description
         updated_relation_file.write("%d,%d\n" % (a, b))
 
+with open(os.path.join(inputdir, seedfile)) as f:
+    updated_seed_file.write(' '.join(str(placement[int(i)]) for i in f.read().split()))
+
+
 updated_node_file.close()
 updated_relation_file.close()
+updated_seed_file.close()

--- a/benchmark/redisgraph/query_runner.py
+++ b/benchmark/redisgraph/query_runner.py
@@ -45,7 +45,7 @@ class RedisGraphQueryRunner(QueryRunner):
           query = "MATCH (s:%s)-[*%d]->(t) WHERE s.id=%d RETURN count(t)" % (self.label, int(depth), int(root))
           result = self.driver.execute_command('graph.query', self.graphid, query)
         except Exception as e:  # timeout, we return -1, reset session
-            print "Exception: %s" % e
+            print("Exception: %s" % e)
             raise e
             return -1
         else:

--- a/benchmark/redisgraph/redisgraph_load_graph500.sh
+++ b/benchmark/redisgraph/redisgraph_load_graph500.sh
@@ -7,7 +7,7 @@ fi
 python generate_graph500_inputs.py $2 || exit 1
 
 # Run RedisGraph bulk import script
-python $1/demo/bulk_insert/bulk_insert.py graph500 -n data/graph500-22_unique_node -r data/graph500-22 || exit 1
+python $1/demo/bulk_insert/bulk_insert.py graph500-22 -n data/graph500-22_unique_node -r data/graph500-22 || exit 1
 
 # Create index on node ID property
-~/redis/src/redis-cli GRAPH.QUERY graph500 "create index on :graph500-22_unique_node(id)"
+~/redis/src/redis-cli GRAPH.QUERY graph500-22 "create index on :graph500-22_unique_node(id)"

--- a/benchmark/redisgraph/redisgraph_load_twitter.sh
+++ b/benchmark/redisgraph/redisgraph_load_twitter.sh
@@ -7,7 +7,7 @@ fi
 python generate_twitter_inputs.py $2 || exit 1
 
 # Run RedisGraph bulk import script
-python $1/demo/bulk_insert/bulk_insert.py twitter_rv -n data/twitter_rv_net_unique_node -r data/twitter_rv || exit 1
+python $1/demo/bulk_insert/bulk_insert.py twitter_rv_net -n data/twitter_rv_net_unique_node -r data/twitter_rv_net || exit 1
 
 # Create index on node ID property
-~/redis/src/redis-cli GRAPH.QUERY twitter_rv "create index on :twitter_rv_net_unique_node(id)"
+~/redis/src/redis-cli GRAPH.QUERY twitter_rv_net "create index on :twitter_rv_net_unique_node(id)"


### PR DESCRIPTION
Hi,

found 2 bugs here.

first is to map seed id. I've noticed when generating inputs, all nodes are mapped to zero-based index. So, the seed nodes should be mapped as well.

the second is `updated_id += 1` should be put after writing to node file.

this solves the wrong `avgKNSize` problem.

But in my test, the `avgQueryTime` is just similar. Really fast, indeed!